### PR TITLE
panel fixes

### DIFF
--- a/packages/apps-components/src/Panel/Panel.js
+++ b/packages/apps-components/src/Panel/Panel.js
@@ -12,7 +12,7 @@ const Panel = function ({ className, title, iconUrl, children })
 
   React.Children.forEach(children, function (child) {
 
-    if (child.type === Action) {
+    if (child && child.type === Action) {
       actions.push(child);
     } else {
       bodyItems.push(child);

--- a/packages/apps-style/src/components/panel.css
+++ b/packages/apps-style/src/components/panel.css
@@ -17,7 +17,7 @@
 }
 
 .dp-AppBody > .dp-Panel {
-  margin-top: 1em
+  margin-top: 1em;
 }
 
 .dp-AppBody > .dp-Panel:first-child {

--- a/packages/apps-style/src/components/panel.css
+++ b/packages/apps-style/src/components/panel.css
@@ -16,3 +16,11 @@
   font-size: var(--h2);
 }
 
+.dp-AppBody > .dp-Panel {
+  margin-top: 1em
+}
+
+.dp-AppBody > .dp-Panel:first-child {
+  margin-top: 0;
+}
+


### PR DESCRIPTION
add spacing between dp-Panel containers when they are direct children of appBody
fix panel fails to ignore non-component react child type